### PR TITLE
support multiple bodies and target selectors.

### DIFF
--- a/__tests__/WebAnnotation.test.js
+++ b/__tests__/WebAnnotation.test.js
@@ -7,6 +7,7 @@ function createSubject(args = {}) {
     canvasId: 'canvasId',
     id: 'id',
     svg: 'svg',
+    tags: ['tags'],
     xywh: 'xywh',
     ...args,
   });
@@ -22,7 +23,23 @@ describe('WebAnnotation', () => {
     });
   });
   describe('target', () => {
-    it('with svg', () => {
+    it('with svg and xywh', () => {
+      expect(subject.target()).toEqual({
+        id: 'canvasId',
+        selector: [
+          {
+            type: 'FragmentSelector',
+            value: 'xywh=xywh',
+          },
+          {
+            type: 'SvgSelector',
+            value: 'svg',
+          },
+        ],
+      });
+    });
+    it('with svg only', () => {
+      subject = createSubject({ xywh: null });
       expect(subject.target()).toEqual({
         id: 'canvasId',
         selector: {
@@ -38,6 +55,36 @@ describe('WebAnnotation', () => {
     it('with no xywh or svg', () => {
       subject = createSubject({ svg: null, xywh: null });
       expect(subject.target()).toBe('canvasId');
+    });
+  });
+  describe('body', () => {
+    it('with text and tags', () => {
+      expect(subject.createBody()).toEqual([
+        {
+          type: 'TextualBody',
+          value: 'body',
+        },
+        {
+          purpose: 'tagging',
+          type: 'TextualBody',
+          value: 'tags',
+        },
+      ]);
+    });
+    it('with text only', () => {
+      subject = createSubject({ tags: null });
+      expect(subject.createBody()).toEqual({
+        type: 'TextualBody',
+        value: 'body',
+      });
+    });
+    it('with tags only', () => {
+      subject = createSubject({ body: null });
+      expect(subject.createBody()).toEqual({
+        purpose: 'tagging',
+        type: 'TextualBody',
+        value: 'tags',
+      });
     });
   });
   describe('toJson', () => {

--- a/src/AnnotationCreation.js
+++ b/src/AnnotationCreation.js
@@ -9,6 +9,9 @@ import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import RectangleIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import CircleIcon from '@material-ui/icons/RadioButtonUnchecked';
 import PolygonIcon from '@material-ui/icons/Timeline';
+import GestureIcon from '@material-ui/icons/Gesture';
+import ClosedPolygonIcon from '@material-ui/icons/ChangeHistory';
+import OpenPolygonIcon from '@material-ui/icons/ShowChart';
 import FormatColorFillIcon from '@material-ui/icons/FormatColorFill';
 import StrokeColorIcon from '@material-ui/icons/BorderColor';
 import LineWeightIcon from '@material-ui/icons/LineWeight';
@@ -62,6 +65,7 @@ class AnnotationCreation extends Component {
     this.state = {
       activeTool: 'cursor',
       annoBody: '',
+      closedMode: 'closed',
       colorPopoverOpen: false,
       currentColorType: false,
       fillColor: null,
@@ -79,6 +83,7 @@ class AnnotationCreation extends Component {
     this.updateBody = this.updateBody.bind(this);
     this.updateGeometry = this.updateGeometry.bind(this);
     this.changeTool = this.changeTool.bind(this);
+    this.changeClosedMode = this.changeClosedMode.bind(this);
     this.openChooseColor = this.openChooseColor.bind(this);
     this.openChooseLineWeight = this.openChooseLineWeight.bind(this);
     this.handleLineWeightSelect = this.handleLineWeightSelect.bind(this);
@@ -181,6 +186,13 @@ class AnnotationCreation extends Component {
   }
 
   /** */
+  changeClosedMode(e) {
+    this.setState({
+      closedMode: e.currentTarget.value,
+    });
+  }
+
+  /** */
   updateBody(annoBody) {
     this.setState({ annoBody });
   }
@@ -200,7 +212,7 @@ class AnnotationCreation extends Component {
 
     const {
       activeTool, colorPopoverOpen, currentColorType, fillColor, popoverAnchorEl, strokeColor,
-      popoverLineWeightAnchorEl, lineWeightPopoverOpen, strokeWidth, annoBody, svg,
+      popoverLineWeightAnchorEl, lineWeightPopoverOpen, strokeWidth, closedMode, annoBody, svg,
     } = this.state;
     return (
       <CompanionWindow
@@ -213,6 +225,7 @@ class AnnotationCreation extends Component {
           fillColor={fillColor}
           strokeColor={strokeColor}
           strokeWidth={strokeWidth}
+          closed={closedMode === 'closed'}
           svg={svg}
           updateGeometry={this.updateGeometry}
           windowId={windowId}
@@ -259,6 +272,9 @@ class AnnotationCreation extends Component {
                   <ToggleButton value="polygon" aria-label="add a polygon">
                     <PolygonIcon />
                   </ToggleButton>
+                  <ToggleButton value="freehand" aria-label="free hand polygon">
+                    <GestureIcon />
+                  </ToggleButton>
                 </ToggleButtonGroup>
               </Paper>
             </Grid>
@@ -299,6 +315,27 @@ class AnnotationCreation extends Component {
                   <ArrowDropDownIcon />
                 </ToggleButton>
               </ToggleButtonGroup>
+
+              <Divider flexItem orientation="vertical" className={classes.divider} />
+              { /* close / open polygon mode only for freehand drawing mode. */
+                activeTool === 'freehand'
+                  ? (
+                    <ToggleButtonGroup
+                      size="small"
+                      value={closedMode}
+                      onChange={this.changeClosedMode}
+                    >
+                      <ToggleButton value="closed">
+                        <ClosedPolygonIcon />
+                      </ToggleButton>
+                      <ToggleButton value="open">
+                        <OpenPolygonIcon />
+                      </ToggleButton>
+                    </ToggleButtonGroup>
+                  )
+                  : null
+              }
+
             </Grid>
           </Grid>
           <Grid container>


### PR DESCRIPTION
Supports a list of bodies to handle (multiple) tags as well as body text. Lays the foundations for #9.

Supports a list of target selectors providing alternate FragmentSelector and SvgSelector. Closes #21.