### PR TITLE
add reference to annotation manifest and fix target source.

### DIFF
--- a/__tests__/WebAnnotation.test.js
+++ b/__tests__/WebAnnotation.test.js
@@ -25,7 +25,6 @@ describe('WebAnnotation', () => {
   describe('target', () => {
     it('with svg and xywh', () => {
       expect(subject.target()).toEqual({
-        id: 'canvasId',
         selector: [
           {
             type: 'FragmentSelector',
@@ -36,21 +35,29 @@ describe('WebAnnotation', () => {
             value: 'svg',
           },
         ],
+        source: 'canvasId',
       });
     });
     it('with svg only', () => {
       subject = createSubject({ xywh: null });
       expect(subject.target()).toEqual({
-        id: 'canvasId',
         selector: {
           type: 'SvgSelector',
           value: 'svg',
         },
+        source: 'canvasId',
       });
     });
     it('with xywh only', () => {
       subject = createSubject({ svg: null });
-      expect(subject.target()).toBe('canvasId#xywh=xywh');
+      /* expect(subject.target()).toBe('canvasId#xywh=xywh'); */
+      expect(subject.target()).toEqual({
+        selector: {
+          type: 'FragmentSelector',
+          value: 'xywh=xywh',
+        },
+        source: 'canvasId',
+      });
     });
     it('with no xywh or svg', () => {
       subject = createSubject({ svg: null, xywh: null });

--- a/__tests__/WebAnnotation.test.js
+++ b/__tests__/WebAnnotation.test.js
@@ -50,7 +50,6 @@ describe('WebAnnotation', () => {
     });
     it('with xywh only', () => {
       subject = createSubject({ svg: null });
-      /* expect(subject.target()).toBe('canvasId#xywh=xywh'); */
       expect(subject.target()).toEqual({
         selector: {
           type: 'FragmentSelector',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.52",
     "lodash": "^4.17.11",
-    "mirador": "^3.0.0-rc.3",
+    "mirador": "^3.0.0-rc.5",
     "prop-types": "^15.7.2",
     "react": "16.x",
     "react-dom": "16.x",

--- a/src/AnnotationCreation.js
+++ b/src/AnnotationCreation.js
@@ -158,6 +158,7 @@ class AnnotationCreation extends Component {
         body: annoBody,
         canvasId: canvas.id,
         id: (annotation && annotation.id) || `${uuid()}`,
+        manifestId: canvas.options.resource.id,
         svg,
         tags,
         xywh,

--- a/src/SimpleAnnotationServerV2Adapter.js
+++ b/src/SimpleAnnotationServerV2Adapter.js
@@ -77,7 +77,7 @@ export default class SimpleAnnotationServerV2Adapter {
       motivation: 'oa:commenting',
       on: {
         '@type': 'oa:SpecificResource',
-        full: v3anno.target.id,
+        full: v3anno.target.source.id,
       },
     };
     // copy id if it is SAS-generated
@@ -100,6 +100,12 @@ export default class SimpleAnnotationServerV2Adapter {
         };
       } else {
         v2anno.on.selector = this.createV2AnnoSelector(v3anno.target.selector);
+      }
+      if (v3anno.target.source.partOf) {
+        v2anno.on.within = {
+          '@id': v3anno.target.source.partOf.id,
+          '@type': 'sc:Manifest',
+        };
       }
     }
     return v2anno;
@@ -172,8 +178,10 @@ export default class SimpleAnnotationServerV2Adapter {
       [v2target] = v2target;
     }
     v3anno.target = {
-      id: v2target.full, // should be source, see #25
       selector: this.createV3AnnoSelector(v2target.selector),
+      source: {
+        id: v2target.full,
+      },
     };
     return v3anno;
   }

--- a/src/SimpleAnnotationServerV2Adapter.js
+++ b/src/SimpleAnnotationServerV2Adapter.js
@@ -179,10 +179,18 @@ export default class SimpleAnnotationServerV2Adapter {
     }
     v3anno.target = {
       selector: this.createV3AnnoSelector(v2target.selector),
-      source: {
-        id: v2target.full,
-      },
+      source: v2target.full,
     };
+    if (v2target.within) {
+      v3anno.target.source = {
+        id: v2target.full,
+        partOf: {
+          id: v2target.within['@id'],
+          type: 'Manifest',
+        },
+        type: 'Canvas',
+      };
+    }
     return v3anno;
   }
 


### PR DESCRIPTION
Adds a reference to manifest of the canvas the annotation targets as `target.source.partOf`. Closes #20
(uses `canvas.options.resource.id` in `AnnotationCreation.js`)

Changes use of `target.id` to `target.source.id`. Closes #25