### PR TITLE
Enforce single canvas view for annotation editor

### DIFF
--- a/__tests__/CanvasListItem.test.js
+++ b/__tests__/CanvasListItem.test.js
@@ -26,6 +26,7 @@ function createWrapper(props, context = {}) {
         canvases: [],
         receiveAnnotation,
         storageAdapter,
+        switchToSingleCanvasView: () => undefined,
         ...context,
       }}
     >

--- a/__tests__/miradorAnnotationPlugin.test.js
+++ b/__tests__/miradorAnnotationPlugin.test.js
@@ -40,4 +40,12 @@ describe('MiradorAnnotation', () => {
       },
     );
   });
+  it('opens single canvas view dialog if not in single view', () => {
+    wrapper = createWrapper({
+      windowViewType: 'book',
+    });
+    expect(wrapper.instance().state.singleCanvasDialogOpen).toBe(false);
+    wrapper.find(MiradorMenuButton).simulate('click');
+    expect(wrapper.instance().state.singleCanvasDialogOpen).toBe(true);
+  });
 });

--- a/__tests__/miradorAnnotationPlugin.test.js
+++ b/__tests__/miradorAnnotationPlugin.test.js
@@ -12,6 +12,8 @@ function createWrapper(props) {
       targetProps={{}}
       addCompanionWindow={jest.fn()}
       receiveAnnotation={jest.fn()}
+      switchToSingleCanvasView={jest.fn()}
+      windowViewType="single"
       {...props}
     />,
   );

--- a/src/CanvasListItem.js
+++ b/src/CanvasListItem.js
@@ -6,7 +6,6 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import flatten from 'lodash/flatten';
 import AnnotationActionsContext from './AnnotationActionsContext';
-import { SingleCanvasDialog } from './SingleCanvasDialog';
 
 /** */
 class CanvasListItem extends Component {
@@ -16,14 +15,11 @@ class CanvasListItem extends Component {
 
     this.state = {
       isHovering: false,
-      singleCanvasDialogOpen: false,
     };
 
     this.handleMouseHover = this.handleMouseHover.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
     this.handleEdit = this.handleEdit.bind(this);
-    this.toggleSingleCanvasDialogOpen = this.toggleSingleCanvasDialogOpen.bind(this);
-    this.switchCanvas = this.switchCanvas.bind(this);
   }
 
   /** */
@@ -87,40 +83,10 @@ class CanvasListItem extends Component {
   }
 
   /** */
-  switchCanvas() {
-    const { annotationsOnCanvases, canvases, setCanvas } = this.context;
-    const { annotationid } = this.props;
-    let canvasId;
-    canvases.forEach((canvas) => {
-      if (annotationsOnCanvases[canvas.id]) {
-        Object.entries(annotationsOnCanvases[canvas.id]).forEach(([key, value], i) => {
-          if (value.json && value.json.items) {
-            const annotation = value.json.items.find((anno) => anno.id === annotationid);
-            if (annotation) {
-              canvasId = canvas.id;
-            }
-          }
-        });
-      }
-    });
-    if (canvasId) {
-      setCanvas(canvasId);
-    }
-  }
-
-  /** */
-  toggleSingleCanvasDialogOpen() {
-    const { singleCanvasDialogOpen } = this.state;
-    this.setState({
-      singleCanvasDialogOpen: !singleCanvasDialogOpen,
-    });
-  }
-
-  /** */
   render() {
     const { children } = this.props;
-    const { isHovering, singleCanvasDialogOpen } = this.state;
-    const { windowViewType, switchToSingleCanvasView } = this.context;
+    const { isHovering } = this.state;
+    const { windowViewType, toggleSingleCanvasDialogOpen } = this.context;
     return (
       <div
         onMouseEnter={this.handleMouseHover}
@@ -144,7 +110,7 @@ class CanvasListItem extends Component {
             >
               <ToggleButton
                 aria-label="Edit"
-                onClick={windowViewType === 'single' ? this.handleEdit : this.toggleSingleCanvasDialogOpen}
+                onClick={windowViewType === 'single' ? this.handleEdit : toggleSingleCanvasDialogOpen}
                 value="edit"
               >
                 <EditIcon />
@@ -154,15 +120,6 @@ class CanvasListItem extends Component {
               </ToggleButton>
             </ToggleButtonGroup>
           </div>
-        )}
-        {windowViewType !== 'single' && (
-          <SingleCanvasDialog
-            handleClose={this.toggleSingleCanvasDialogOpen}
-            open={singleCanvasDialogOpen}
-            openCreateAnnotationCompanionWindow={this.handleEdit}
-            setCanvas={this.switchCanvas}
-            switchToSingleCanvasView={switchToSingleCanvasView}
-          />
         )}
         <li
           {...this.props} // eslint-disable-line react/jsx-props-no-spreading

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -66,8 +66,6 @@ class SingleCanvasDialog extends Component {
 SingleCanvasDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
-  // openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
-  // setCanvas: PropTypes.func,
   switchToSingleCanvasView: PropTypes.func.isRequired,
 };
 

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -8,23 +8,38 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 
+/**
+ * Dialog to enforce single view for annotation creation / editing
+ */
 export class SingleCanvasDialog extends Component {
+  /** */
   constructor(props) {
     super(props);
     this.confirm = this.confirm.bind(this);
   }
 
+  /** */
   confirm() {
-    this.props.switchToSingleCanvasView();
-    this.props.openCreateAnnotationCompanionWindow();
-    this.props.handleClose();
+    const {
+      handleClose,
+      openCreateAnnotationCompanionWindow,
+      switchToSingleCanvasView,
+    } = this.props;
+    switchToSingleCanvasView();
+    openCreateAnnotationCompanionWindow();
+    handleClose();
   }
 
+  /** */
   render() {
+    const {
+      handleClose,
+      open,
+    } = this.props;
     return (
       <Dialog
-        onClose={this.props.hideDialog}
-        open={this.props.open}
+        onClose={handleClose}
+        open={open}
       >
         <DialogTitle disableTypography>
           <Typography variant="h2">
@@ -33,13 +48,14 @@ export class SingleCanvasDialog extends Component {
         </DialogTitle>
         <DialogContent>
           <DialogContentText variant="body2" color="inherit">
-            Annotations can only be edited in single canvas view type. Switch view type to single view now?
+            Annotations can only be edited in single canvas view type.
+            Switch view type to single view now?
           </DialogContentText>
           <DialogActions>
             <Button onClick={this.confirm} variant="contained">
               Switch and start annotating
             </Button>
-            <Button onClick={this.props.handleClose} variant="contained">
+            <Button onClick={handleClose} variant="contained">
               Cancel
             </Button>
           </DialogActions>
@@ -54,8 +70,8 @@ SingleCanvasDialog.propTypes = {
   open: PropTypes.bool,
   openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
   switchToSingleCanvasView: PropTypes.func.isRequired,
-}
+};
 
 SingleCanvasDialog.defaultProps = {
   open: false,
-}
+};

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -36,28 +36,32 @@ class SingleCanvasDialog extends Component {
     } = this.props;
     return (
       <Dialog
+        aria-labelledby="single-canvas-dialog-title"
+        fullWidth
+        maxWidth="sm"
         onClose={handleClose}
+        onEscapeKeyDown={handleClose}
         open={open}
       >
-        <DialogTitle disableTypography>
+        <DialogTitle id="single-canvas-dialog-title" disableTypography>
           <Typography variant="h2">
             Switch view type to single view?
           </Typography>
         </DialogTitle>
         <DialogContent>
-          <DialogContentText variant="body2" color="inherit">
+          <DialogContentText variant="body1" color="inherit">
             Annotations can only be edited in single canvas view type.
             Switch view type to single view now?
           </DialogContentText>
-          <DialogActions>
-            <Button onClick={this.confirm} variant="contained">
-              Switch to single view
-            </Button>
-            <Button onClick={handleClose} variant="contained">
-              Cancel
-            </Button>
-          </DialogActions>
         </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button color="primary" onClick={this.confirm} variant="contained">
+            Switch to single view
+          </Button>
+        </DialogActions>
       </Dialog>
     );
   }

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
+
+export class SingleCanvasDialog extends Component {
+  constructor(props) {
+    super(props);
+    this.confirm = this.confirm.bind(this);
+  }
+
+  confirm() {
+    this.props.switchToSingleCanvasView();
+    this.props.openCreateAnnotationCompanionWindow();
+    this.props.handleClose();
+  }
+
+  render() {
+    return (
+      <Dialog
+        onClose={this.props.hideDialog}
+        open={this.props.open}
+      >
+        <DialogTitle disableTypography>
+          <Typography variant="h2">
+            Switch view type to single view?
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText variant="body2" color="inherit">
+            Annotations can only be edited in single canvas view type. Switch view type to single view now?
+          </DialogContentText>
+          <DialogActions>
+            <Button onClick={this.confirm} variant="contained">
+              Switch and start annotating
+            </Button>
+            <Button onClick={this.props.handleClose} variant="contained">
+              Cancel
+            </Button>
+          </DialogActions>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+SingleCanvasDialog.propTypes = {
+  handleClose: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+  openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
+  switchToSingleCanvasView: PropTypes.func.isRequired,
+}
+
+SingleCanvasDialog.defaultProps = {
+  open: false,
+}

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Dialog to enforce single view for annotation creation / editing
  */
-export class SingleCanvasDialog extends Component {
+class SingleCanvasDialog extends Component {
   /** */
   constructor(props) {
     super(props);
@@ -22,13 +22,9 @@ export class SingleCanvasDialog extends Component {
   confirm() {
     const {
       handleClose,
-      openCreateAnnotationCompanionWindow,
-      setCanvas,
       switchToSingleCanvasView,
     } = this.props;
     switchToSingleCanvasView();
-    setCanvas();
-    openCreateAnnotationCompanionWindow();
     handleClose();
   }
 
@@ -55,7 +51,7 @@ export class SingleCanvasDialog extends Component {
           </DialogContentText>
           <DialogActions>
             <Button onClick={this.confirm} variant="contained">
-              Switch and start annotating
+              Switch to single view
             </Button>
             <Button onClick={handleClose} variant="contained">
               Cancel
@@ -70,12 +66,13 @@ export class SingleCanvasDialog extends Component {
 SingleCanvasDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
-  openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
-  setCanvas: PropTypes.func,
+  // openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
+  // setCanvas: PropTypes.func,
   switchToSingleCanvasView: PropTypes.func.isRequired,
 };
 
 SingleCanvasDialog.defaultProps = {
   open: false,
-  setCanvas: () => undefined,
 };
+
+export default SingleCanvasDialog;

--- a/src/SingleCanvasDialog.js
+++ b/src/SingleCanvasDialog.js
@@ -23,9 +23,11 @@ export class SingleCanvasDialog extends Component {
     const {
       handleClose,
       openCreateAnnotationCompanionWindow,
+      setCanvas,
       switchToSingleCanvasView,
     } = this.props;
     switchToSingleCanvasView();
+    setCanvas();
     openCreateAnnotationCompanionWindow();
     handleClose();
   }
@@ -69,9 +71,11 @@ SingleCanvasDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   openCreateAnnotationCompanionWindow: PropTypes.func.isRequired,
+  setCanvas: PropTypes.func,
   switchToSingleCanvasView: PropTypes.func.isRequired,
 };
 
 SingleCanvasDialog.defaultProps = {
   open: false,
+  setCanvas: () => undefined,
 };

--- a/src/plugins/canvasAnnotationsPlugin.js
+++ b/src/plugins/canvasAnnotationsPlugin.js
@@ -5,15 +5,34 @@ import * as actions from 'mirador/dist/es/src/state/actions';
 import { getWindowViewType } from 'mirador/dist/es/src/state/selectors';
 import CanvasListItem from '../CanvasListItem';
 import AnnotationActionsContext from '../AnnotationActionsContext';
+import SingleCanvasDialog from '../SingleCanvasDialog';
 
 /** */
 class CanvasAnnotationsWrapper extends Component {
   /** */
+  constructor(props) {
+    super(props);
+    this.state = {
+      singleCanvasDialogOpen: false,
+    };
+    this.toggleSingleCanvasDialogOpen = this.toggleSingleCanvasDialogOpen.bind(this);
+  }
+
+  /** */
+  toggleSingleCanvasDialogOpen() {
+    const { singleCanvasDialogOpen } = this.state;
+    this.setState({
+      singleCanvasDialogOpen: !singleCanvasDialogOpen,
+    });
+  }
+
+  /** */
   render() {
     const {
       addCompanionWindow, annotationsOnCanvases, canvases, config, receiveAnnotation,
-      setCanvas, switchToSingleCanvasView, TargetComponent, targetProps, windowViewType,
+      switchToSingleCanvasView, TargetComponent, targetProps, windowViewType,
     } = this.props;
+    const { singleCanvasDialogOpen } = this.state;
     const props = {
       ...targetProps,
       listContainerComponent: CanvasListItem,
@@ -26,9 +45,8 @@ class CanvasAnnotationsWrapper extends Component {
           canvases,
           config,
           receiveAnnotation,
-          setCanvas,
           storageAdapter: config.annotation.adapter,
-          switchToSingleCanvasView,
+          toggleSingleCanvasDialogOpen: this.toggleSingleCanvasDialogOpen,
           windowId: targetProps.windowId,
           windowViewType,
         }}
@@ -36,6 +54,13 @@ class CanvasAnnotationsWrapper extends Component {
         <TargetComponent
           {...props} // eslint-disable-line react/jsx-props-no-spreading
         />
+        {windowViewType !== 'single' && (
+          <SingleCanvasDialog
+            handleClose={this.toggleSingleCanvasDialogOpen}
+            open={singleCanvasDialogOpen}
+            switchToSingleCanvasView={switchToSingleCanvasView}
+          />
+        )}
       </AnnotationActionsContext.Provider>
     );
   }
@@ -53,7 +78,6 @@ CanvasAnnotationsWrapper.propTypes = {
     }),
   }).isRequired,
   receiveAnnotation: PropTypes.func.isRequired,
-  setCanvas: PropTypes.func.isRequired,
   switchToSingleCanvasView: PropTypes.func.isRequired,
   TargetComponent: PropTypes.oneOfType([
     PropTypes.func,
@@ -94,9 +118,6 @@ const mapDispatchToProps = (dispatch, props) => ({
   ),
   receiveAnnotation: (targetId, id, annotation) => dispatch(
     actions.receiveAnnotation(targetId, id, annotation),
-  ),
-  setCanvas: (canvasId) => dispatch(
-    actions.setCanvas(props.targetProps.windowId, canvasId),
   ),
   switchToSingleCanvasView: () => dispatch(
     actions.setWindowViewType(props.targetProps.windowId, 'single'),

--- a/src/plugins/canvasAnnotationsPlugin.js
+++ b/src/plugins/canvasAnnotationsPlugin.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
 import * as actions from 'mirador/dist/es/src/state/actions';
+import { getWindowViewType } from 'mirador/dist/es/src/state/selectors';
 import CanvasListItem from '../CanvasListItem';
 import AnnotationActionsContext from '../AnnotationActionsContext';
 
@@ -10,8 +11,8 @@ class CanvasAnnotationsWrapper extends Component {
   /** */
   render() {
     const {
-      addCompanionWindow, canvases, config, receiveAnnotation, TargetComponent,
-      targetProps, annotationsOnCanvases,
+      addCompanionWindow, annotationsOnCanvases, canvases, config, receiveAnnotation,
+      setCanvas, switchToSingleCanvasView, TargetComponent, targetProps, windowViewType,
     } = this.props;
     const props = {
       ...targetProps,
@@ -25,8 +26,11 @@ class CanvasAnnotationsWrapper extends Component {
           canvases,
           config,
           receiveAnnotation,
+          setCanvas,
           storageAdapter: config.annotation.adapter,
+          switchToSingleCanvasView,
           windowId: targetProps.windowId,
+          windowViewType,
         }}
       >
         <TargetComponent
@@ -49,11 +53,14 @@ CanvasAnnotationsWrapper.propTypes = {
     }),
   }).isRequired,
   receiveAnnotation: PropTypes.func.isRequired,
+  setCanvas: PropTypes.func.isRequired,
+  switchToSingleCanvasView: PropTypes.func.isRequired,
   TargetComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.node,
   ]).isRequired,
   targetProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  windowViewType: PropTypes.string.isRequired,
 };
 
 CanvasAnnotationsWrapper.defaultProps = {
@@ -65,6 +72,7 @@ CanvasAnnotationsWrapper.defaultProps = {
 function mapStateToProps(state, { targetProps: { windowId } }) {
   const canvases = getVisibleCanvases(state, { windowId });
   const annotationsOnCanvases = {};
+
   canvases.forEach((canvas) => {
     const anno = state.annotations[canvas.id];
     if (anno) {
@@ -75,6 +83,7 @@ function mapStateToProps(state, { targetProps: { windowId } }) {
     annotationsOnCanvases,
     canvases,
     config: state.config,
+    windowViewType: getWindowViewType(state, { windowId }),
   };
 }
 
@@ -85,6 +94,12 @@ const mapDispatchToProps = (dispatch, props) => ({
   ),
   receiveAnnotation: (targetId, id, annotation) => dispatch(
     actions.receiveAnnotation(targetId, id, annotation),
+  ),
+  setCanvas: (canvasId) => dispatch(
+    actions.setCanvas(props.targetProps.windowId, canvasId),
+  ),
+  switchToSingleCanvasView: () => dispatch(
+    actions.setWindowViewType(props.targetProps.windowId, 'single'),
   ),
 });
 

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -6,7 +6,6 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
 import { SingleCanvasDialog } from '../SingleCanvasDialog';
 
-
 /** */
 class MiradorAnnotation extends Component {
   /** */
@@ -30,15 +29,23 @@ class MiradorAnnotation extends Component {
     });
   }
 
+  /** */
   toggleSingleCanvasDialogOpen() {
+    const { singleCanvasDialogOpen } = this.state;
     this.setState({
-      singleCanvasDialogOpen: !this.state.singleCanvasDialogOpen,
+      singleCanvasDialogOpen: !singleCanvasDialogOpen,
     });
   }
 
   /** */
   render() {
-    const { TargetComponent, targetProps } = this.props;
+    const {
+      switchToSingleCanvasView,
+      TargetComponent,
+      targetProps,
+      windowViewType,
+    } = this.props;
+    const { singleCanvasDialogOpen } = this.state;
     return (
       <div>
         <TargetComponent
@@ -46,18 +53,18 @@ class MiradorAnnotation extends Component {
         />
         <MiradorMenuButton
           aria-label="Create new annotation"
-          onClick={this.props.windowViewType === 'single' ? this.openCreateAnnotationCompanionWindow : this.toggleSingleCanvasDialogOpen}
+          onClick={windowViewType === 'single' ? this.openCreateAnnotationCompanionWindow : this.toggleSingleCanvasDialogOpen}
           size="small"
         >
           <AddBoxIcon />
         </MiradorMenuButton>
         {
-          this.state.singleCanvasDialogOpen && (
+          singleCanvasDialogOpen && (
             <SingleCanvasDialog
-              open={this.state.singleCanvasDialogOpen}
+              open={singleCanvasDialogOpen}
               handleClose={this.toggleSingleCanvasDialogOpen}
               openCreateAnnotationCompanionWindow={this.openCreateAnnotationCompanionWindow}
-              switchToSingleCanvasView={this.props.switchToSingleCanvasView}
+              switchToSingleCanvasView={switchToSingleCanvasView}
             />
           )
         }
@@ -68,11 +75,13 @@ class MiradorAnnotation extends Component {
 
 MiradorAnnotation.propTypes = {
   addCompanionWindow: PropTypes.func.isRequired,
+  switchToSingleCanvasView: PropTypes.func.isRequired,
   TargetComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.node,
   ]).isRequired,
   targetProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  windowViewType: PropTypes.string.isRequired,
 };
 
 /** */
@@ -81,10 +90,11 @@ const mapDispatchToProps = (dispatch, props) => ({
     actions.addCompanionWindow(props.targetProps.windowId, { content, ...additionalProps }),
   ),
   switchToSingleCanvasView: () => dispatch(
-    actions.setWindowViewType(props.targetProps.windowId, 'single')
-  )
+    actions.setWindowViewType(props.targetProps.windowId, 'single'),
+  ),
 });
 
+/** */
 const mapStateToProps = (state, props) => ({
   windowViewType: getWindowViewType(state, { windowId: props.targetProps.windowId }),
 });

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -4,7 +4,7 @@ import * as actions from 'mirador/dist/es/src/state/actions';
 import { getWindowViewType } from 'mirador/dist/es/src/state/selectors';
 import AddBoxIcon from '@material-ui/icons/AddBox';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
-import { SingleCanvasDialog } from '../SingleCanvasDialog';
+import SingleCanvasDialog from '../SingleCanvasDialog';
 
 /** */
 class MiradorAnnotation extends Component {
@@ -63,7 +63,6 @@ class MiradorAnnotation extends Component {
             <SingleCanvasDialog
               open={singleCanvasDialogOpen}
               handleClose={this.toggleSingleCanvasDialogOpen}
-              openCreateAnnotationCompanionWindow={this.openCreateAnnotationCompanionWindow}
               switchToSingleCanvasView={switchToSingleCanvasView}
             />
           )

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -1,15 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as actions from 'mirador/dist/es/src/state/actions';
+import { getWindowViewType } from 'mirador/dist/es/src/state/selectors';
 import AddBoxIcon from '@material-ui/icons/AddBox';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
+import { SingleCanvasDialog } from '../SingleCanvasDialog';
+
 
 /** */
 class MiradorAnnotation extends Component {
   /** */
   constructor(props) {
     super(props);
+    this.state = {
+      singleCanvasDialogOpen: false,
+    };
     this.openCreateAnnotationCompanionWindow = this.openCreateAnnotationCompanionWindow.bind(this);
+    this.toggleSingleCanvasDialogOpen = this.toggleSingleCanvasDialogOpen.bind(this);
   }
 
   /** */
@@ -23,6 +30,12 @@ class MiradorAnnotation extends Component {
     });
   }
 
+  toggleSingleCanvasDialogOpen() {
+    this.setState({
+      singleCanvasDialogOpen: !this.state.singleCanvasDialogOpen,
+    });
+  }
+
   /** */
   render() {
     const { TargetComponent, targetProps } = this.props;
@@ -33,11 +46,21 @@ class MiradorAnnotation extends Component {
         />
         <MiradorMenuButton
           aria-label="Create new annotation"
-          onClick={this.openCreateAnnotationCompanionWindow}
+          onClick={this.props.windowViewType === 'single' ? this.openCreateAnnotationCompanionWindow : this.toggleSingleCanvasDialogOpen}
           size="small"
         >
           <AddBoxIcon />
         </MiradorMenuButton>
+        {
+          this.state.singleCanvasDialogOpen && (
+            <SingleCanvasDialog
+              open={this.state.singleCanvasDialogOpen}
+              handleClose={this.toggleSingleCanvasDialogOpen}
+              openCreateAnnotationCompanionWindow={this.openCreateAnnotationCompanionWindow}
+              switchToSingleCanvasView={this.props.switchToSingleCanvasView}
+            />
+          )
+        }
       </div>
     );
   }
@@ -57,11 +80,19 @@ const mapDispatchToProps = (dispatch, props) => ({
   addCompanionWindow: (content, additionalProps) => dispatch(
     actions.addCompanionWindow(props.targetProps.windowId, { content, ...additionalProps }),
   ),
+  switchToSingleCanvasView: () => dispatch(
+    actions.setWindowViewType(props.targetProps.windowId, 'single')
+  )
+});
+
+const mapStateToProps = (state, props) => ({
+  windowViewType: getWindowViewType(state, { windowId: props.targetProps.windowId }),
 });
 
 export default {
   component: MiradorAnnotation,
   mapDispatchToProps,
+  mapStateToProps,
   mode: 'wrap',
   target: 'AnnotationSettings',
 };


### PR DESCRIPTION
As there are currently some problems with annotation creation / editing in views with more than one visible canvas (see #24), this PR adds a dialog that is displayed if a user clicks the "New Annotation" icon in any other than `single` view.

What's still missing in this PR is a similar behavior for the edit button.