### PR TITLE
Offer localstorage annotations for "download"

### DIFF
--- a/__tests__/AnnotationExportDialog.test.js
+++ b/__tests__/AnnotationExportDialog.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import MenuItem from '@material-ui/core/MenuItem';
+import AnnotationExportDialog from '../src/AnnotationExportDialog';
+
+window.URL.createObjectURL = jest.fn((data) => ('downloadurl'));
+
+const adapter = jest.fn(() => (
+  {
+    all: jest.fn().mockResolvedValue(
+      {
+        id: 'pageId/3',
+        items: [
+          { id: 'anno/2' },
+        ],
+        type: 'AnnotationPage',
+      },
+    ),
+    annotationPageId: 'pageId/3',
+  }
+));
+
+/** */
+function createWrapper(props) {
+  return shallow(
+    <AnnotationExportDialog
+      canvases={[]}
+      config={{ annotation: { adapter } }}
+      handleClose={jest.fn()}
+      open
+      {...props}
+    />,
+  );
+}
+
+describe('AnnotationExportDialog', () => {
+  it('renders download link for every annotation page', async () => {
+    let wrapper = createWrapper({
+      canvases: [
+        { id: 'canvas/1' },
+        { id: 'canvas/2' },
+      ],
+    }).dive();
+    expect(wrapper.text()).toEqual(expect.stringContaining('No annotations stored yet.'));
+
+    wrapper.instance().componentDidUpdate({ open: false });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    wrapper = wrapper.update();
+    expect(wrapper.text()).toEqual(expect.not.stringContaining('No annotations stored yet.'));
+    expect(wrapper.find(MenuItem).some({ 'aria-label': 'Export annotations for canvas/1' })).toBe(true);
+    expect(wrapper.find(MenuItem).some({ 'aria-label': 'Export annotations for canvas/2' })).toBe(true);
+  });
+});

--- a/__tests__/miradorAnnotationPlugin.test.js
+++ b/__tests__/miradorAnnotationPlugin.test.js
@@ -7,6 +7,7 @@ import miradorAnnotationPlugin from '../src/plugins/miradorAnnotationPlugin';
 function createWrapper(props) {
   return shallow(
     <miradorAnnotationPlugin.component
+      canvases={[]}
       config={{}}
       TargetComponent="<div>hello</div>"
       targetProps={{}}

--- a/__tests__/miradorAnnotationPlugin.test.js
+++ b/__tests__/miradorAnnotationPlugin.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
+import LocalStorageAdapter from '../src/LocalStorageAdapter';
 import miradorAnnotationPlugin from '../src/plugins/miradorAnnotationPlugin';
 
 /** */
@@ -38,5 +39,39 @@ describe('MiradorAnnotation', () => {
         position: 'right',
       },
     );
+  });
+  it('renders no export button if export or LocalStorageAdapter are not configured', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find(MiradorMenuButton).some({ 'aria-label': 'Export local annotations for visible items' })).toBe(false);
+
+    wrapper = createWrapper({
+      config: {
+        annotation: {
+          adapter: () => () => {},
+          exportLocalStorageAnnotations: true,
+        },
+      },
+    });
+    expect(wrapper.find(MiradorMenuButton).some({ 'aria-label': 'Export local annotations for visible items' })).toBe(false);
+
+    wrapper = createWrapper({
+      config: {
+        annotation: {
+          adapter: (canvasId) => new LocalStorageAdapter(`test://?canvasId=${canvasId}`),
+        },
+      },
+    });
+    expect(wrapper.find(MiradorMenuButton).some({ 'aria-label': 'Export local annotations for visible items' })).toBe(false);
+  });
+  it('renders export button if export and LocalStorageAdapter are configured', () => {
+    wrapper = createWrapper({
+      config: {
+        annotation: {
+          adapter: (canvasId) => new LocalStorageAdapter(`test://?canvasId=${canvasId}`),
+          exportLocalStorageAnnotations: true,
+        },
+      },
+    });
+    expect(wrapper.find(MiradorMenuButton).some({ 'aria-label': 'Export local annotations for visible items' })).toBe(true);
   });
 });

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -9,7 +9,7 @@ const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`),
     // adapter: (canvasId) => new AnnototAdapter(canvasId, endpointUrl),
-    // downloadCanvasAnnotations: true,
+    downloadLocalStorageAnnotations: false,
   },
   id: 'demo',
   window: {

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -9,7 +9,7 @@ const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`),
     // adapter: (canvasId) => new AnnototAdapter(canvasId, endpointUrl),
-    exportLocalStorageAnnotations: false,
+    exportLocalStorageAnnotations: false, // display annotation JSON export button
   },
   id: 'demo',
   window: {

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -9,7 +9,7 @@ const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`),
     // adapter: (canvasId) => new AnnototAdapter(canvasId, endpointUrl),
-    downloadLocalStorageAnnotations: false,
+    exportLocalStorageAnnotations: false,
   },
   id: 'demo',
   window: {

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -9,6 +9,7 @@ const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`),
     // adapter: (canvasId) => new AnnototAdapter(canvasId, endpointUrl),
+    // downloadCanvasAnnotations: true,
   },
   id: 'demo',
   window: {

--- a/src/AnnotationDownloadDialog.js
+++ b/src/AnnotationDownloadDialog.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+import ListItemText from '@material-ui/core/ListItemText'
+import Typography from '@material-ui/core/Typography';
+import PropTypes, { bool } from 'prop-types';
+
+export class AnnotationDownloadDialog extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      downloadLinks: [],
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { canvases, config, open } = this.props;
+    const { open: prevOpen } = prevProps || {};
+    if (prevOpen !== open && open) {
+      const reducer = async (acc, canvas) => {
+        const store = config.annotation.adapter(canvas.id);
+        const _acc = await acc;
+        const content = await store.all();
+        if (content
+          ) {
+          const label = canvas.__jsonld.label || canvas.id;
+          const data = new Blob([JSON.stringify(content)], { type: 'application/json' })
+          const url = window.URL.createObjectURL(data);
+          return [..._acc, {
+            id: content.id || content['@id'],
+            canvasId: canvas.id,
+            label,
+            url,
+          }]
+        }
+        return _acc;
+      }
+      if (canvases && canvases.length > 0) {
+        canvases.reduce(reducer, []).then(downloadLinks => {
+          this.setState({ downloadLinks })
+        });
+      } else {
+        this.setState({ downloadLinks: [] });
+      }
+    }
+    if (prevOpen !== open && !open) {
+      this.setState({ downloadLinks: [] });
+    }
+  }
+
+  render() {
+    const { canvases, config, handleClose, open } = this.props;
+    return (
+      <Dialog
+        aria-labelledby="annotation-download-dialog-title"
+        id="annotation-download-dialog"
+        onClose={handleClose}
+        onEscapeKeyDown={handleClose}
+        open={open}
+      >
+        <DialogTitle id="annotation-download-dialog-title" disableTypography>
+          <Typography variant="h2">Download Annotations</Typography>
+        </DialogTitle>
+        <DialogContent>
+          { this.state.downloadLinks === undefined || this.state.downloadLinks.length === 0 ? (
+            <Typography variant="body1">No annotations stored yet.</Typography>
+          ) : (
+            <List>
+              {this.state.downloadLinks.map(dl => (
+              <ListItem button
+                component="a"
+                key={dl.canvasId}
+                aria-label={`Download annotations for ${dl.label}`}
+                startIcon={<GetAppIcon/>}
+                href={dl.url}
+                download={`annotations-${dl.id}.json`}
+              >
+                <ListItemIcon>
+                  <GetAppIcon/>
+                </ListItemIcon>
+                <ListItemText>
+                  Download annotations for {dl.label}
+                </ListItemText>
+              </ListItem>
+              ))}
+            </List>
+          )}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+}
+
+AnnotationDownloadDialog.propTypes = {
+  canvases: PropTypes.arrayOf(
+    PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
+  ),
+  config: PropTypes.shape({
+    annotation: PropTypes.shape({
+      adapter: PropTypes.func,
+    }),
+  }),
+  handleClose: PropTypes.func.isRequired,
+  open: bool.isRequired,
+}

--- a/src/AnnotationDownloadDialog.js
+++ b/src/AnnotationDownloadDialog.js
@@ -86,15 +86,14 @@ export class AnnotationDownloadDialog extends Component {
                   component="a"
                   key={dl.canvasId}
                   aria-label={`Download annotations for ${dl.label}`}
-                  startIcon={<GetAppIcon />}
                   href={dl.url}
-                  download={`annotations-${dl.id}.json`}
+                  download={`${dl.id}.json`}
                 >
                   <ListItemIcon>
                     <GetAppIcon />
                   </ListItemIcon>
                   <ListItemText>
-                    {`Download annotations for canvas "${dl.label}"`}
+                    {`Download annotations for "${dl.label}"`}
                   </ListItemText>
                 </ListItem>
               ))}

--- a/src/AnnotationDownloadDialog.js
+++ b/src/AnnotationDownloadDialog.js
@@ -3,108 +3,118 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import List from '@material-ui/core/List'
-import ListItem from '@material-ui/core/ListItem'
-import ListItemIcon from '@material-ui/core/ListItemIcon'
-import ListItemText from '@material-ui/core/ListItemText'
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import PropTypes, { bool } from 'prop-types';
 
+/** */
 export class AnnotationDownloadDialog extends Component {
+  /** */
   constructor(props) {
     super(props);
     this.state = {
       downloadLinks: [],
-    }
+    };
+    this.closeDialog = this.closeDialog.bind(this);
   }
 
+  /** */
   componentDidUpdate(prevProps) {
     const { canvases, config, open } = this.props;
     const { open: prevOpen } = prevProps || {};
     if (prevOpen !== open && open) {
+      /** */
       const reducer = async (acc, canvas) => {
         const store = config.annotation.adapter(canvas.id);
-        const _acc = await acc;
+        const resolvedAcc = await acc;
         const content = await store.all();
-        if (content
-          ) {
+        if (content) {
+          // eslint-disable-next-line no-underscore-dangle
           const label = canvas.__jsonld.label || canvas.id;
-          const data = new Blob([JSON.stringify(content)], { type: 'application/json' })
+          const data = new Blob([JSON.stringify(content)], { type: 'application/json' });
           const url = window.URL.createObjectURL(data);
-          return [..._acc, {
-            id: content.id || content['@id'],
+          return [...resolvedAcc, {
             canvasId: canvas.id,
+            id: content.id || content['@id'],
             label,
             url,
-          }]
+          }];
         }
-        return _acc;
-      }
+        return resolvedAcc;
+      };
       if (canvases && canvases.length > 0) {
-        canvases.reduce(reducer, []).then(downloadLinks => {
-          this.setState({ downloadLinks })
+        canvases.reduce(reducer, []).then((downloadLinks) => {
+          this.setState({ downloadLinks });
         });
-      } else {
-        this.setState({ downloadLinks: [] });
       }
-    }
-    if (prevOpen !== open && !open) {
-      this.setState({ downloadLinks: [] });
     }
   }
 
+  /** */
+  closeDialog() {
+    const { handleClose } = this.props;
+    this.setState({ downloadLinks: [] });
+    handleClose();
+  }
+
+  /** */
   render() {
-    const { canvases, config, handleClose, open } = this.props;
+    const { handleClose, open } = this.props;
+    const { downloadLinks } = this.state;
     return (
       <Dialog
         aria-labelledby="annotation-download-dialog-title"
         id="annotation-download-dialog"
         onClose={handleClose}
-        onEscapeKeyDown={handleClose}
+        onEscapeKeyDown={this.closeDialog}
         open={open}
       >
         <DialogTitle id="annotation-download-dialog-title" disableTypography>
           <Typography variant="h2">Download Annotations</Typography>
         </DialogTitle>
         <DialogContent>
-          { this.state.downloadLinks === undefined || this.state.downloadLinks.length === 0 ? (
+          { downloadLinks === undefined || downloadLinks.length === 0 ? (
             <Typography variant="body1">No annotations stored yet.</Typography>
           ) : (
             <List>
-              {this.state.downloadLinks.map(dl => (
-              <ListItem button
-                component="a"
-                key={dl.canvasId}
-                aria-label={`Download annotations for ${dl.label}`}
-                startIcon={<GetAppIcon/>}
-                href={dl.url}
-                download={`annotations-${dl.id}.json`}
-              >
-                <ListItemIcon>
-                  <GetAppIcon/>
-                </ListItemIcon>
-                <ListItemText>
-                  Download annotations for {dl.label}
-                </ListItemText>
-              </ListItem>
+              { downloadLinks.map((dl) => (
+                <ListItem
+                  button
+                  component="a"
+                  key={dl.canvasId}
+                  aria-label={`Download annotations for ${dl.label}`}
+                  startIcon={<GetAppIcon />}
+                  href={dl.url}
+                  download={`annotations-${dl.id}.json`}
+                >
+                  <ListItemIcon>
+                    <GetAppIcon />
+                  </ListItemIcon>
+                  <ListItemText>
+                    {`Download annotations for canvas "${dl.label}"`}
+                  </ListItemText>
+                </ListItem>
               ))}
             </List>
           )}
         </DialogContent>
       </Dialog>
-    )
+    );
   }
 }
 
 AnnotationDownloadDialog.propTypes = {
   canvases: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
-  ),
+  ).isRequired,
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
     }),
-  }),
+  }).isRequired,
   handleClose: PropTypes.func.isRequired,
   open: bool.isRequired,
-}
+};

--- a/src/AnnotationDownloadDialog.js
+++ b/src/AnnotationDownloadDialog.js
@@ -11,7 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import PropTypes, { bool } from 'prop-types';
 
 /** */
-export class AnnotationDownloadDialog extends Component {
+class AnnotationDownloadDialog extends Component {
   /** */
   constructor(props) {
     super(props);
@@ -117,3 +117,5 @@ AnnotationDownloadDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: bool.isRequired,
 };
+
+export default AnnotationDownloadDialog;

--- a/src/AnnotationExportDialog.js
+++ b/src/AnnotationExportDialog.js
@@ -11,12 +11,12 @@ import Typography from '@material-ui/core/Typography';
 import PropTypes, { bool } from 'prop-types';
 
 /** */
-class AnnotationDownloadDialog extends Component {
+class AnnotationExportDialog extends Component {
   /** */
   constructor(props) {
     super(props);
     this.state = {
-      downloadLinks: [],
+      exportLinks: [],
     };
     this.closeDialog = this.closeDialog.bind(this);
   }
@@ -46,8 +46,8 @@ class AnnotationDownloadDialog extends Component {
         return resolvedAcc;
       };
       if (canvases && canvases.length > 0) {
-        canvases.reduce(reducer, []).then((downloadLinks) => {
-          this.setState({ downloadLinks });
+        canvases.reduce(reducer, []).then((exportLinks) => {
+          this.setState({ exportLinks });
         });
       }
     }
@@ -56,36 +56,36 @@ class AnnotationDownloadDialog extends Component {
   /** */
   closeDialog() {
     const { handleClose } = this.props;
-    this.setState({ downloadLinks: [] });
+    this.setState({ exportLinks: [] });
     handleClose();
   }
 
   /** */
   render() {
     const { handleClose, open } = this.props;
-    const { downloadLinks } = this.state;
+    const { exportLinks } = this.state;
     return (
       <Dialog
-        aria-labelledby="annotation-download-dialog-title"
-        id="annotation-download-dialog"
+        aria-labelledby="annotation-export-dialog-title"
+        id="annotation-export-dialog"
         onClose={handleClose}
         onEscapeKeyDown={this.closeDialog}
         open={open}
       >
-        <DialogTitle id="annotation-download-dialog-title" disableTypography>
-          <Typography variant="h2">Download Annotations</Typography>
+        <DialogTitle id="annotation-export-dialog-title" disableTypography>
+          <Typography variant="h2">Export Annotations</Typography>
         </DialogTitle>
         <DialogContent>
-          { downloadLinks === undefined || downloadLinks.length === 0 ? (
+          { exportLinks === undefined || exportLinks.length === 0 ? (
             <Typography variant="body1">No annotations stored yet.</Typography>
           ) : (
             <List>
-              { downloadLinks.map((dl) => (
+              { exportLinks.map((dl) => (
                 <ListItem
                   button
                   component="a"
                   key={dl.canvasId}
-                  aria-label={`Download annotations for ${dl.label}`}
+                  aria-label={`Export annotations for ${dl.label}`}
                   href={dl.url}
                   download={`${dl.id}.json`}
                 >
@@ -93,7 +93,7 @@ class AnnotationDownloadDialog extends Component {
                     <GetAppIcon />
                   </ListItemIcon>
                   <ListItemText>
-                    {`Download annotations for "${dl.label}"`}
+                    {`Export annotations for "${dl.label}"`}
                   </ListItemText>
                 </ListItem>
               ))}
@@ -105,7 +105,7 @@ class AnnotationDownloadDialog extends Component {
   }
 }
 
-AnnotationDownloadDialog.propTypes = {
+AnnotationExportDialog.propTypes = {
   canvases: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
   ).isRequired,
@@ -118,4 +118,4 @@ AnnotationDownloadDialog.propTypes = {
   open: bool.isRequired,
 };
 
-export default AnnotationDownloadDialog;
+export default AnnotationExportDialog;

--- a/src/AnnotationExportDialog.js
+++ b/src/AnnotationExportDialog.js
@@ -3,12 +3,24 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
 import Typography from '@material-ui/core/Typography';
 import PropTypes, { bool } from 'prop-types';
+import { withStyles } from '@material-ui/core';
+
+const styles = theme => ({
+  listitem: {
+    '&:focus': {
+      backgroundColor: theme.palette.action.focus,
+    },
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+})
 
 /** */
 class AnnotationExportDialog extends Component {
@@ -62,7 +74,7 @@ class AnnotationExportDialog extends Component {
 
   /** */
   render() {
-    const { handleClose, open } = this.props;
+    const { classes, handleClose, open } = this.props;
     const { exportLinks } = this.state;
     return (
       <Dialog
@@ -79,10 +91,11 @@ class AnnotationExportDialog extends Component {
           { exportLinks === undefined || exportLinks.length === 0 ? (
             <Typography variant="body1">No annotations stored yet.</Typography>
           ) : (
-            <List>
+            <MenuList>
               { exportLinks.map((dl) => (
-                <ListItem
+                <MenuItem
                   button
+                  className={classes.listitem}
                   component="a"
                   key={dl.canvasId}
                   aria-label={`Export annotations for ${dl.label}`}
@@ -95,9 +108,9 @@ class AnnotationExportDialog extends Component {
                   <ListItemText>
                     {`Export annotations for "${dl.label}"`}
                   </ListItemText>
-                </ListItem>
+                </MenuItem>
               ))}
-            </List>
+            </MenuList>
           )}
         </DialogContent>
       </Dialog>
@@ -118,4 +131,4 @@ AnnotationExportDialog.propTypes = {
   open: bool.isRequired,
 };
 
-export default AnnotationExportDialog;
+export default withStyles(styles)(AnnotationExportDialog);

--- a/src/AnnotationExportDialog.js
+++ b/src/AnnotationExportDialog.js
@@ -11,7 +11,8 @@ import Typography from '@material-ui/core/Typography';
 import PropTypes, { bool } from 'prop-types';
 import { withStyles } from '@material-ui/core';
 
-const styles = theme => ({
+/** */
+const styles = (theme) => ({
   listitem: {
     '&:focus': {
       backgroundColor: theme.palette.action.focus,
@@ -20,7 +21,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.action.hover,
     },
   },
-})
+});
 
 /** */
 class AnnotationExportDialog extends Component {
@@ -122,6 +123,7 @@ AnnotationExportDialog.propTypes = {
   canvases: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
   ).isRequired,
+  classes: PropTypes.objectOf(PropTypes.string),
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
@@ -129,6 +131,10 @@ AnnotationExportDialog.propTypes = {
   }).isRequired,
   handleClose: PropTypes.func.isRequired,
   open: bool.isRequired,
+};
+
+AnnotationExportDialog.defaultProps = {
+  classes: {},
 };
 
 export default withStyles(styles)(AnnotationExportDialog);

--- a/src/AnnotationExportDialog.js
+++ b/src/AnnotationExportDialog.js
@@ -46,7 +46,7 @@ class AnnotationExportDialog extends Component {
         const content = await store.all();
         if (content) {
           // eslint-disable-next-line no-underscore-dangle
-          const label = canvas.__jsonld.label || canvas.id;
+          const label = (canvas.__jsonld && canvas.__jsonld.label) || canvas.id;
           const data = new Blob([JSON.stringify(content)], { type: 'application/json' });
           const url = window.URL.createObjectURL(data);
           return [...resolvedAcc, {
@@ -121,7 +121,7 @@ class AnnotationExportDialog extends Component {
 
 AnnotationExportDialog.propTypes = {
   canvases: PropTypes.arrayOf(
-    PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
+    PropTypes.shape({ id: PropTypes.string }),
   ).isRequired,
   classes: PropTypes.objectOf(PropTypes.string),
   config: PropTypes.shape({

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -5,7 +5,7 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
 import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
-import AnnotationDownloadDialog from '../AnnotationDownloadDialog';
+import AnnotationExportDialog from '../AnnotationExportDialog';
 import LocalStorageAdapter from '../LocalStorageAdapter';
 
 /** */
@@ -14,10 +14,10 @@ class MiradorAnnotation extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      annotationDownloadDialogOpen: false,
+      annotationExportDialogOpen: false,
     };
     this.openCreateAnnotationCompanionWindow = this.openCreateAnnotationCompanionWindow.bind(this);
-    this.toggleCanvasDownloadDialog = this.toggleCanvasDownloadDialog.bind(this);
+    this.toggleCanvasExportDialog = this.toggleCanvasExportDialog.bind(this);
   }
 
   /** */
@@ -32,10 +32,10 @@ class MiradorAnnotation extends Component {
   }
 
   /** */
-  toggleCanvasDownloadDialog(e) {
-    const { annotationDownloadDialogOpen } = this.state;
+  toggleCanvasExportDialog(e) {
+    const { annotationExportDialogOpen } = this.state;
     const newState = {
-      annotationDownloadDialogOpen: !annotationDownloadDialogOpen,
+      annotationExportDialogOpen: !annotationExportDialogOpen,
     };
     this.setState(newState);
   }
@@ -45,10 +45,10 @@ class MiradorAnnotation extends Component {
     const {
       canvases, config, TargetComponent, targetProps,
     } = this.props;
-    const { annotationDownloadDialogOpen } = this.state;
+    const { annotationExportDialogOpen } = this.state;
     const storageAdapter = config.annotation && config.annotation.adapter('poke');
-    const offerDownloadDialog = config.annotation && storageAdapter instanceof LocalStorageAdapter
-      && config.annotation.downloadLocalStorageAnnotations;
+    const offerExportDialog = config.annotation && storageAdapter instanceof LocalStorageAdapter
+      && config.annotation.exportLocalStorageAnnotations;
     return (
       <div>
         <TargetComponent
@@ -61,21 +61,21 @@ class MiradorAnnotation extends Component {
         >
           <AddBoxIcon />
         </MiradorMenuButton>
-        { offerDownloadDialog && (
+        { offerExportDialog && (
           <MiradorMenuButton
-            aria-label="Download local annotations for visible items"
-            onClick={this.toggleCanvasDownloadDialog}
+            aria-label="Export local annotations for visible items"
+            onClick={this.toggleCanvasExportDialog}
             size="small"
           >
             <GetAppIcon />
           </MiradorMenuButton>
         )}
-        { offerDownloadDialog && (
-          <AnnotationDownloadDialog
+        { offerExportDialog && (
+          <AnnotationExportDialog
             canvases={canvases}
             config={config}
-            handleClose={this.toggleCanvasDownloadDialog}
-            open={annotationDownloadDialogOpen}
+            handleClose={this.toggleCanvasExportDialog}
+            open={annotationExportDialogOpen}
           />
         )}
       </div>
@@ -91,7 +91,7 @@ MiradorAnnotation.propTypes = {
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
-      downloadLocalStorageAnnotations: PropTypes.bool,
+      exportLocalStorageAnnotations: PropTypes.bool,
     }),
   }).isRequired,
   TargetComponent: PropTypes.oneOfType([

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -5,7 +5,7 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
 import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
-import { AnnotationDownloadDialog } from '../AnnotationDownloadDialog';
+import AnnotationDownloadDialog from '../AnnotationDownloadDialog';
 import LocalStorageAdapter from '../LocalStorageAdapter';
 
 /** */

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -30,17 +30,22 @@ class MiradorAnnotation extends Component {
     });
   }
 
+  /** */
   toggleCanvasDownloadDialog(e) {
+    const { annotationDownloadDialogOpen } = this.state;
     const newState = {
-      annotationDownloadDialogOpen: !this.state.annotationDownloadDialogOpen,
-    }
+      annotationDownloadDialogOpen: !annotationDownloadDialogOpen,
+    };
     this.setState(newState);
   }
 
   /** */
   render() {
-    const { canvases, config, TargetComponent, targetProps } = this.props;
-    const showAnnotationDownloadDialog = config.annotation && config.annotation.downloadCanvasAnnotations;
+    const {
+      canvases, config, TargetComponent, targetProps,
+    } = this.props;
+    const { annotationDownloadDialogOpen } = this.state;
+    const showDownloadDialog = config.annotation && config.annotation.downloadCanvasAnnotations;
     return (
       <div>
         <TargetComponent
@@ -53,7 +58,7 @@ class MiradorAnnotation extends Component {
         >
           <AddBoxIcon />
         </MiradorMenuButton>
-        { showAnnotationDownloadDialog && (
+        { showDownloadDialog && (
           <MiradorMenuButton
             aria-label="Download annotation page for canvas"
             onClick={this.toggleCanvasDownloadDialog}
@@ -62,12 +67,12 @@ class MiradorAnnotation extends Component {
             <GetAppIcon />
           </MiradorMenuButton>
         )}
-        { showAnnotationDownloadDialog && (
+        { showDownloadDialog && (
           <AnnotationDownloadDialog
             canvases={canvases}
             config={config}
             handleClose={this.toggleCanvasDownloadDialog}
-            open={this.state.annotationDownloadDialogOpen}
+            open={annotationDownloadDialogOpen}
           />
         )}
       </div>
@@ -79,13 +84,13 @@ MiradorAnnotation.propTypes = {
   addCompanionWindow: PropTypes.func.isRequired,
   canvases: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
-  ),
+  ).isRequired,
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
       downloadCanvasAnnotations: PropTypes.bool,
     }),
-  }),
+  }).isRequired,
   TargetComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.node,
@@ -100,12 +105,11 @@ const mapDispatchToProps = (dispatch, props) => ({
   ),
 });
 
-const mapStateToProps = function mapStateToProps(state, { targetProps: { windowId } }) {
-  return {
-    canvases: getVisibleCanvases(state, { windowId }),
-    config: state.config,
-  };
-}
+/** */
+const mapStateToProps = (state, { targetProps: { windowId } }) => ({
+  canvases: getVisibleCanvases(state, { windowId }),
+  config: state.config,
+});
 
 export default {
   component: MiradorAnnotation,

--- a/src/plugins/miradorAnnotationPlugin.js
+++ b/src/plugins/miradorAnnotationPlugin.js
@@ -6,6 +6,7 @@ import GetAppIcon from '@material-ui/icons/GetApp';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
 import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
 import { AnnotationDownloadDialog } from '../AnnotationDownloadDialog';
+import LocalStorageAdapter from '../LocalStorageAdapter';
 
 /** */
 class MiradorAnnotation extends Component {
@@ -45,7 +46,9 @@ class MiradorAnnotation extends Component {
       canvases, config, TargetComponent, targetProps,
     } = this.props;
     const { annotationDownloadDialogOpen } = this.state;
-    const showDownloadDialog = config.annotation && config.annotation.downloadCanvasAnnotations;
+    const storageAdapter = config.annotation && config.annotation.adapter('poke');
+    const offerDownloadDialog = config.annotation && storageAdapter instanceof LocalStorageAdapter
+      && config.annotation.downloadLocalStorageAnnotations;
     return (
       <div>
         <TargetComponent
@@ -58,16 +61,16 @@ class MiradorAnnotation extends Component {
         >
           <AddBoxIcon />
         </MiradorMenuButton>
-        { showDownloadDialog && (
+        { offerDownloadDialog && (
           <MiradorMenuButton
-            aria-label="Download annotation page for canvas"
+            aria-label="Download local annotations for visible items"
             onClick={this.toggleCanvasDownloadDialog}
             size="small"
           >
             <GetAppIcon />
           </MiradorMenuButton>
         )}
-        { showDownloadDialog && (
+        { offerDownloadDialog && (
           <AnnotationDownloadDialog
             canvases={canvases}
             config={config}
@@ -88,7 +91,7 @@ MiradorAnnotation.propTypes = {
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
-      downloadCanvasAnnotations: PropTypes.bool,
+      downloadLocalStorageAnnotations: PropTypes.bool,
     }),
   }).isRequired,
   TargetComponent: PropTypes.oneOfType([


### PR DESCRIPTION
Localstorage annotations are bound to a single browser user profile and are obviously quite volatile. This PR would introduce an option for users to save the annotation pages for the canvases in the current view to a local drive outside the browser and reuse them for other purposes.

The download is only availabe if `downloadLocalStorageAnnotations = true` is configured in the Mirador config.