### PR TITLE
Update SimpleAnnotationServerV2Adapter.js

### DIFF
--- a/src/SimpleAnnotationServerV2Adapter.js
+++ b/src/SimpleAnnotationServerV2Adapter.js
@@ -77,7 +77,7 @@ export default class SimpleAnnotationServerV2Adapter {
       motivation: 'oa:commenting',
       on: {
         '@type': 'oa:SpecificResource',
-        full: v3anno.target.source.id,
+        full: v3anno.target.source,
       },
     };
     // copy id if it is SAS-generated


### PR DESCRIPTION
Using SimpleAnnotationServerV2Adapter.js with Mirador 3.1.1. and mirador-annotation plugin 0.5.0, it appears that the V3 annotation structure has changed slightly.  This causes line 80 (full: v3anno.target.source.id) of SimpleAnnotationServerV2Adapter.js not to fucntion properly -- the "full" JSON key will not have a canvadIS URI value.

changing line 80: full: v3anno.target.source.id
to: full: v3anno.target.source

fixes the issue and enables SimpleAnnotationServerV2Adapter.js to output the correct canvasID s