### PR TITLE
Mark the current line-weight as selected; fixes #36

### DIFF
--- a/src/AnnotationCreation.js
+++ b/src/AnnotationCreation.js
@@ -367,12 +367,15 @@ class AnnotationCreation extends Component {
         >
           <Paper>
             <ClickAwayListener onClickAway={this.handleCloseLineWeight}>
-              <MenuList>
+              <MenuList autoFocus role="listbox">
                 {[1, 3, 5, 10, 50].map((option, index) => (
                   <MenuItem
                     key={option}
                     onClick={this.handleLineWeightSelect}
                     value={option}
+                    selected={option == strokeWidth}
+                    role="option"
+                    aria-selected={option == strokeWidth}
                   >
                     {option}
                   </MenuItem>


### PR DESCRIPTION
![Screen Shot 2021-06-16 at 09 45 12](https://user-images.githubusercontent.com/111218/122259936-8d368780-ce87-11eb-88fd-cad73f466cb8.png)
