### PR TITLE
fix WADM target.source

### DIFF
--- a/src/WebAnnotation.js
+++ b/src/WebAnnotation.js
@@ -81,11 +81,11 @@ export default class WebAnnotation {
   /** */
   source() {
     let source = this.canvasId;
-    if (this.manifest) {
+    if (this.manifestId) {
       source = {
         id: this.canvasId,
         partOf: {
-          id: this.manifest.id,
+          id: this.manifestId,
           type: 'Manifest',
         },
         type: 'Canvas',


### PR DESCRIPTION
Due to a typo, source manifest was not being injected in target.source.partOf.